### PR TITLE
Add optional closure for custom validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty_paseto"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2018"
 resolver = "2"
 

--- a/src/claims.rs
+++ b/src/claims.rs
@@ -1,9 +1,7 @@
-//  //use crate::common::{PurposeLocal, V2};
 use crate::errors::{Iso8601ParseError, TokenClaimError};
 use crate::traits::PasetoClaim;
 use serde::ser::SerializeMap;
 use std::convert::From;
-//  use std::marker::PhantomData;
 use std::convert::{AsRef, TryFrom};
 
 #[derive(Clone, Debug)]
@@ -12,6 +10,20 @@ pub struct CustomClaim<T>((String, T));
 impl<T> PasetoClaim for CustomClaim<T> {
   fn get_key(&self) -> &str {
     &self.0 .0
+  }
+}
+
+impl TryFrom<&str> for CustomClaim<&str> {
+  type Error = TokenClaimError;
+
+  fn try_from(val: &str) -> Result<Self, Self::Error> {
+    let key = val;
+    match key {
+      key if ["iss", "sub", "aud", "exp", "nbf", "iat", "jti"].contains(&key) => {
+        Err(TokenClaimError::ReservedClaim(key.into()))
+      }
+      _ => Ok(Self((String::from(val), ""))),
+    }
   }
 }
 
@@ -56,6 +68,12 @@ impl<'a> PasetoClaim for IssuedAtClaim<'a> {
   }
 }
 
+impl<'a> Default for IssuedAtClaim<'a> {
+  fn default() -> Self {
+    Self(("iat", "2019-01-01T00:00:00+00:00"))
+  }
+}
+
 impl<'a> TryFrom<&'a str> for IssuedAtClaim<'a> {
   type Error = Iso8601ParseError;
 
@@ -91,6 +109,12 @@ pub struct NotBeforeClaim<'a>((&'a str, &'a str));
 impl<'a> PasetoClaim for NotBeforeClaim<'a> {
   fn get_key(&self) -> &str {
     self.0 .0
+  }
+}
+
+impl<'a> Default for NotBeforeClaim<'a> {
+  fn default() -> Self {
+    Self(("nbf", "2019-01-01T00:00:00+00:00"))
   }
 }
 
@@ -132,6 +156,12 @@ impl<'a> PasetoClaim for ExpirationClaim<'a> {
   }
 }
 
+impl<'a> Default for ExpirationClaim<'a> {
+  fn default() -> Self {
+    Self(("exp", "2019-01-01T00:00:00+00:00"))
+  }
+}
+
 impl<'a> TryFrom<&'a str> for ExpirationClaim<'a> {
   type Error = Iso8601ParseError;
 
@@ -170,6 +200,12 @@ impl<'a> PasetoClaim for TokenIdentifierClaim<'a> {
   }
 }
 
+impl<'a> Default for TokenIdentifierClaim<'a> {
+  fn default() -> Self {
+    Self(("jti", ""))
+  }
+}
+
 //created using the From trait
 impl<'a> From<&'a str> for TokenIdentifierClaim<'a> {
   fn from(s: &'a str) -> Self {
@@ -202,6 +238,12 @@ pub struct AudienceClaim<'a>((&'a str, &'a str));
 impl<'a> PasetoClaim for AudienceClaim<'a> {
   fn get_key(&self) -> &str {
     self.0 .0
+  }
+}
+
+impl<'a> Default for AudienceClaim<'a> {
+  fn default() -> Self {
+    Self(("aud", ""))
   }
 }
 
@@ -241,6 +283,12 @@ impl<'a> PasetoClaim for SubjectClaim<'a> {
   }
 }
 
+impl<'a> Default for SubjectClaim<'a> {
+  fn default() -> Self {
+    Self(("sub", ""))
+  }
+}
+
 //created using the From trait
 impl<'a> From<&'a str> for SubjectClaim<'a> {
   fn from(s: &'a str) -> Self {
@@ -272,6 +320,12 @@ pub struct IssuerClaim<'a>((&'a str, &'a str));
 impl<'a> PasetoClaim for IssuerClaim<'a> {
   fn get_key(&self) -> &str {
     self.0 .0
+  }
+}
+
+impl<'a> Default for IssuerClaim<'a> {
+  fn default() -> Self {
+    Self(("iss", ""))
   }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -31,8 +31,12 @@ pub enum GenericTokenBuilderError {
 /// Potential errors from attempting to parse a token string
 #[derive(Debug, Error)]
 pub enum PasetoTokenParseError {
+  #[error("The claim {0} was not the expected type")]
+  InvalidClaimValueType(String),
   #[error("The claim {0} failed downcasting")]
   DowncastClaim(String),
+  #[error("A custom claim validator for claim '{0}' failed for value '{1}'")]
+  CustomClaimValidation(String, String),
   #[error("The claim '{0}' failed validation")]
   InvalidClaim(String),
   #[error("This string has an incorrect number of parts and cannot be parsed into a token")]


### PR DESCRIPTION
- add: Added an optional closure argument to the validate_claim method.
  To be used to allow the user to provide custom validation logic for a
  particular claim

- add: Added logic in the parse method to run custom validation closures
  if one is specified.  This means claim validators will verify the
  claim exists and verify the value matches what is expected.  If a
  custom closure is provided, the validator first checks the claim
  exists and then the value is provided to the closure for further
  validation by the end user.

- add: PasetoTokenParseError::InvalidClaimValueType(String) for claim
  values we try to convert to an invalid type

- add: PasetoTokenParseError::CustomClaimValidation for claims which
  fail in user provided custom validation closures

- add: Implement Default trait on all reserved claims so that they can
  be passed into custom validation closures

- add: Implement From(&str) for CustomClaim so that they can be passed
  into custom validation closures which always ignore passed in values
  when adding the claim to the validator

- chore: closes #1