### PR TITLE
Solve the Conflicting implementation of the `From<ed25519_dalek::ed25519::Error> for PasetoError`

### DIFF
--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -104,6 +104,9 @@ pub enum PasetoError {
   },
 }
 
+
+/// It seems that when this trait is implemented when the `p384` feature is enabled
+/// it results in a conflicting implementation. So this is done to avoid the conflict.
 #[cfg(all(feature = "ed25519-dalek", not(feature = "p384")))]
 impl From<ed25519_dalek::ed25519::Error> for PasetoError {
   fn from(source: ed25519_dalek::ed25519::Error) -> Self {

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -35,7 +35,6 @@ pub enum PasetoError {
   #[error("An unspecified cipher error occurred")]
   RsaCipher {
     ///An RSA cipher error
-    #[from]
     source: ed25519_dalek::ed25519::Error,
   },
   #[cfg(feature = "p384")]
@@ -103,4 +102,11 @@ pub enum PasetoError {
     #[from]
     source: std::string::FromUtf8Error,
   },
+}
+
+#[cfg(all(feature = "ed25519-dalek", not(feature = "p384")))]
+impl From<ed25519_dalek::ed25519::Error> for PasetoError {
+  fn from(source: ed25519_dalek::ed25519::Error) -> Self {
+      PasetoError::RsaCipher{source}
+  }
 }

--- a/tests/build_payload_from_claims_prop_test.rs
+++ b/tests/build_payload_from_claims_prop_test.rs
@@ -51,7 +51,6 @@
 use std::collections::HashMap;
 
 use proptest::prelude::*;
-use erased_serde::Serialize;
 use serde_json::{Map, Number, Value};
 
 // Define a strategy to generate arbitrary JSON values


### PR DESCRIPTION
This error happens when the `v3_public` features is enable in combination with all or any of these other features:

1. `v1_public`
2. `v2_public`
3. `v3_public`

**Why is this happening? **
i could not get to the exact cause of this error but this solves the error.
when the above 3 features are enabled, they also enable the `ed25519_dalek` feature crate. and the `v3_public` feature enables the `p384` feature crate. When the Error macro of thiserror derive the `From<p384::ecdsa::Error> for PasetoError` it also seems to create an implementation of `From<ed25519_dalek::ed25519::Error> for PasetoError`. This also happens when I did manual implementation of both traits. I could not figure the root cause for this behavior. and the from macro on the `RsaCipher` error variant also results in an implementation of this trait which results in a conflict. So i have manually implemented the `From<ed25519_dalek::ed25519::Error> for PasetoError` under a feature that only allows it's compilation when the `ed25519_dalek` is enabled and `p384` feature is disabled, and this solves the error and all the 81 tests are passing when all the features are enabled as expected.