### PR TITLE
fix(deps): update aes dependency from 0.7 to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ v3 = []
 v4 = []
 public = []
 local = []
-v1_local = ["v1", "local", "core", "aes", "chacha20", "hmac", "sha2", "blake2"]
+v1_local = ["v1", "local", "core", "aes", "ctr", "chacha20", "hmac", "sha2", "blake2"]
 v2_local = ["v2", "local", "core", "blake2", "chacha20poly1305"]
-v3_local = ["v3", "local", "core", "aes", "hmac", "sha2", "chacha20"]
+v3_local = ["v3", "local", "core", "aes", "ctr", "hmac", "sha2", "chacha20"]
 v4_local = ["v4", "local", "core", "blake2", "chacha20"]
 v1_public = ["v1", "public", "core", "ed25519-dalek"]
 v2_public = ["v2", "public", "core", "ed25519-dalek", "ring/std"]
@@ -55,7 +55,8 @@ serde_json = { version = "1.0", optional = true }
 thiserror = "1.0"
 iso8601 = "0.6"
 erased-serde = { version = "0.4", optional = true }
-aes = { version = "0.7", features = ["ctr"], optional = true }
+aes = { version = "0.8", optional = true }
+ctr = { version = "0.9", optional = true }
 hmac = { version = "0.12", optional = true }
 sha2 = { version = "0.10", optional = true }
 zeroize = { version = "1.4", features = ["zeroize_derive"] }

--- a/src/core/common/cipher_text_impl/v1_local.rs
+++ b/src/core/common/cipher_text_impl/v1_local.rs
@@ -1,11 +1,14 @@
 #![cfg(feature = "v1_local")]
 use std::marker::PhantomData;
-use aes::Aes256Ctr;
-use aes::cipher::generic_array::GenericArray;
-use aes::cipher::{NewCipher, StreamCipher};
+use aes::Aes256;
+use ctr::cipher::{KeyIvInit, StreamCipher};
+use ctr::cipher::generic_array::GenericArray;
+use ctr::Ctr128BE;
 use crate::core::common::cipher_text::CipherText;
 use crate::core::{Local, V1};
 use crate::core::common::EncryptionKey;
+
+type Aes256Ctr = Ctr128BE<Aes256>;
 
 impl CipherText<V1, Local> {
     pub(crate) fn from(payload: &[u8], encryption_key: &EncryptionKey<V1, Local>) -> Self {

--- a/src/core/common/cipher_text_impl/v3_local.rs
+++ b/src/core/common/cipher_text_impl/v3_local.rs
@@ -1,10 +1,13 @@
 #![cfg(feature = "v3_local")]
 use std::marker::PhantomData;
-use aes::Aes256Ctr;
-use aes::cipher::generic_array::GenericArray;
-use aes::cipher::{NewCipher, StreamCipher};
+use aes::Aes256;
+use ctr::cipher::{KeyIvInit, StreamCipher};
+use ctr::cipher::generic_array::GenericArray;
+use ctr::Ctr128BE;
 use crate::core::common::{CipherText, EncryptionKey};
 use crate::core::{Local, V3};
+
+type Aes256Ctr = Ctr128BE<Aes256>;
 
 impl CipherText<V3, Local> {
     pub(crate) fn from(payload: &[u8], encryption_key: &EncryptionKey<V3, Local>) -> Self {


### PR DESCRIPTION
## Changes

Updates `aes` dependency from 0.7 to 0.8 and migrates to standalone `ctr` crate.

### Dependencies
- `aes`: 0.7 → 0.8 (removed `ctr` feature)
- `ctr`: 0.9 (new dependency)

### Implementation
- `v1_local.rs`: Uses `ctr::Ctr128BE<Aes256>` instead of `aes::Aes256Ctr`
- `v3_local.rs`: Uses `ctr::Ctr128BE<Aes256>` instead of `aes::Aes256Ctr`
- `Cargo.toml`: Adds `ctr` to `v1_local` and `v3_local` feature flags

### Migration Pattern
```rust
// Before (aes 0.7)
use aes::Aes256Ctr;
use aes::cipher::{NewCipher, StreamCipher};

// After (aes 0.8 + ctr 0.9)
use aes::Aes256;
use ctr::Ctr128BE;
use ctr::cipher::{KeyIvInit, StreamCipher};

type Aes256Ctr = Ctr128BE<Aes256>;
```

Cipher traits now import from `ctr::cipher` (re-exports from `cipher` crate). Encryption logic remains unchanged.

## Testing

All feature combinations pass:
```bash
cargo nextest run --no-default-features --features v1_local  # ✓ 12 tests
cargo nextest run --no-default-features --features v3_local  # ✓ 16 tests
cargo nextest run --no-default-features --features v2_local  # ✓ 14 tests
cargo nextest run --no-default-features --features v4_local  # ✓ 13 tests
cargo nextest run --no-default-features --features v1_public # ✓ 8 tests
cargo nextest run --no-default-features --features v2_public # ✓ 10 tests
cargo nextest run --no-default-features --features v3_public # ✓ 7 tests
cargo nextest run --no-default-features --features v4_public # ✓ 10 tests
cargo nextest run                                             # ✓ 36 tests (default)
```

## Rationale

RustCrypto removed the `ctr` feature from `aes` 0.8. The `aes` crate provides low-level block cipher operations. Stream cipher modes like CTR now require the standalone `ctr` crate.

This follows RustCrypto's architectural design where block ciphers and cipher modes are separate crates.

Closes #54