### PR TITLE
ci: add automated release creation on version tags

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,8 @@ on:
         required: true
         type: string
 name: Continuous integration
+permissions:
+  contents: read
 jobs:
   default-features:
     name: Default Features (batteries_included + v4)
@@ -105,6 +107,8 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     needs: [default-features, test, clippy, audit]
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,16 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., v0.8.0)'
+        required: true
+        type: string
 name: Continuous integration
 jobs:
   default-features:
@@ -87,3 +99,34 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo audit
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    needs: [default-features, test, clippy, audit]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Build release binary
+        run: cargo build --release
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG_NAME="${{ github.event.inputs.tag }}"
+          else
+            TAG_NAME=${GITHUB_REF#refs/tags/}
+          fi
+          gh release create "$TAG_NAME" \
+            --title "Release $TAG_NAME" \
+            --notes "See [CHANGELOG](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details." \
+            --draft=false \
+            --prerelease=false


### PR DESCRIPTION
## Summary
- Adds automated release creation when version tags (v*.*.*) are pushed
- Release job runs after all CI tests pass (default-features, test, clippy, audit)
- Builds release binaries and creates GitHub release with changelog reference

## Manual Release Support
- Adds workflow_dispatch trigger for creating releases from existing tags
- Enables retroactive release creation (e.g., for v0.8.0)
- Access via GitHub Actions → "Run workflow" → enter tag name

## Changes
- Updates workflow trigger to include tag push events
- Adds release job with dependency on all test jobs
- Configures checkout to support both automatic and manual tag releases